### PR TITLE
[WIP]DBの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 |nickname|string|null: false|
 |profile|text||
 |image|string|default: ""|
-|password|string|null: false|
+|email|string|default: "", index: true, unique: true|
+|encrypted_password|string|null: false|
+|reset_password_token|string|index: true|
+
  
 ### Association
 - has_many :items
@@ -48,7 +51,6 @@
 |title|string||null: false|null: false|
 |category|references|null: false, foreign_key: true|
 |status|integer|null: false|
-|region|integer|null: false|
 |shipping_charge|integer|null: false|
 |delivery_source|integer|null: false|
 |shipping_day|integer|null: false|

--- a/db/migrate/20191101224819_remove_password_to_users.rb
+++ b/db/migrate/20191101224819_remove_password_to_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordToUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_30_080004) do
+ActiveRecord::Schema.define(version: 2019_11_01_224819) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "family_name", null: false
@@ -34,6 +34,15 @@ ActiveRecord::Schema.define(version: 2019_10_30_080004) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_cards_on_user_id"
+  end
+
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "text"
+    t.bigint "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_id"], name: "index_categories_on_parent_id"
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -98,7 +107,6 @@ ActiveRecord::Schema.define(version: 2019_10_30_080004) do
     t.string "image", default: ""
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "password", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
# What
・itemsテーブルのregionカラムを削除したので、READMEの編集
・usersテーブルのpasswordカラムはdeviseが勝手に作ってくれていたので要りませんでした(encrypted_passwordというカラム)。なので削除します。その後README編集

# Why
DB管理をスムーズにするため。
（同じマイグレーションファイルが複数できてしまうと、本番環境で少しだけ手間である。）