### PR TITLE
【マークアップ】ユーザークレジットカード登録ページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @import "user/mypage";
 @import "user/private-informations.scss";
 @import "user/profile.scss";
+@import "card.scss";

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -1,0 +1,56 @@
+.card__content {
+  width: 700px;
+  height: 350px;
+  background-color: white;
+  float: right;
+  p {
+    text-align: center;
+    line-height: 50px;
+    font-size: 25px;
+    font-weight: bold;
+  }
+}
+
+.card__content__box {
+  border-top: solid 2px #f0f0f0;
+  p {
+    text-align: center;
+    font-size: 15px;
+    font-weight: bold;
+    position: relative;
+    top: 53px;
+    right: 53px;
+  }
+}
+
+.card {
+  width: 260px;
+  height: 50px;
+  background-color: red;
+  margin: auto;
+  position: relative;
+  top: 50px;
+  i {
+    position: relative;
+    top: 18px;
+    left: 30px;
+  }
+}
+
+.card__link {
+  color: white;
+  text-decoration: none;
+}
+
+.payment {
+  width: 80%;
+  margin: auto;
+  border-top: solid 2px #f0f0f0;
+  position: relative;
+  top: 80px;
+  &__link {
+    float: right;
+    position: relative;
+    top: 30px;
+  }
+}

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,2 +1,6 @@
 class CardsController < ApplicationController
+
+  def index
+  end
+  
 end

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -1,0 +1,25 @@
+.item-index__wrapper
+  .item-index__container 
+    .bread-crumds
+      %ul.bread-crumds__list
+        %li
+          = link_to "" do
+            %span<> 
+              メルカリ
+          %i.fas.chevron-right
+        %li マイページ
+
+    .mypage-container
+      .card__content
+        %p 支払い方法
+        .card__content__box
+          %p クレジットカード一覧
+          .card
+            %i.far.fa-credit-card
+              = link_to 'クレジットカードを追加する', 'https://www.mercari.com/jp/mypage/card/create/', method: :create, class: 'card__link'
+
+          .payment
+            = link_to '支払い方法について＞', 'https://www.mercari.com/jp/help_center/category/6/', method: :get, class: 'payment__link'
+
+      .side-mypage
+        = render 'users/side_bar'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,9 +12,8 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: [:show, :edit] do
-    resources :private_informations, only: [:new] do
+    resources :private_informations, only: [:new]
     resources :cards, only: [:index]
-    end
   end
 
   resources :items do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: [:show, :edit] do
-    resources :private_informations, only: [:new]
+    resources :private_informations, only: [:new] do
+    resources :cards, only: [:index]
+    end
   end
 
   resources :items do


### PR DESCRIPTION
# What
ユーザークレジットカード登録ページのコーディングをしました。
haml/sassを使用しています。
下記のページと同じような見た目ができています。
https://www.mercari.com/jp/mypage/card/

ローカルでは下記のようなURLで確認
http://localhost:3000/users/1/cards

gyazo
https://gyazo.com/31169ce85678c669fd11d6dbfe3db08f

# Why
ユーザーがクレジットカードを登録する時に必要な画面となります。
