### PR TITLE
新規登録機能の修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -75,8 +75,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
       # ログインするための情報を保管
       session[:id] = @user.id
       redirect_to complete_users_path
-    else
-      redirect_to root_path
     end
   end
 
@@ -173,7 +171,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       house_number:          "仮",
       building_name:         "仮"
     )
-    render :sms unless @user.valid?
+    render :sms unless @user.valid?(:sms)
   end
 
   def validates_address

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,8 +39,7 @@ class User < ApplicationRecord
   validates :prefectures,   presence: true
   validates :city,          presence: true
   validates :house_number,  presence: true
-  validates :building_name, presence: true
-  validates :phone_number,  presence: true
+  validates :phone_number,  presence: true, on: :sms
 
   enum prefectures: {
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/app/views/users/registrations/new_address.html.haml
+++ b/app/views/users/registrations/new_address.html.haml
@@ -8,9 +8,9 @@
           = f.label "郵便番号"
           %span.information__group__require  必須
           = f.text_field :postal_code, placeholder: "例) 1234567", class: "information__group__text"
-          - if @user.errors.messages[:phone_number].any?
+          - if @user.errors.messages[:postal_code].any?
             %p.user_error
-              = @user.errors.messages[:phone_number][0]
+              = @user.errors.messages[:postal_code][0]
 
         .information__group
           = f.label "都道府県"
@@ -42,16 +42,10 @@
           = f.label "建物名"
           %span.information__group__arbitrary  任意
           = f.text_field :building_name, placeholder: "例) 柳ビル103", class: "information__group__text"
-          - if @user.errors.messages[:building_name].any?
-            %p.user_error
-              = @user.errors.messages[:building_name][0]
 
         .information__group
           = f.label "電話"
           %span.information__group__arbitrary  任意
           = f.text_field :phone_number, placeholder: "例) 09012345678", class: "information__group__text"
-          - if @user.errors.messages[:phone_number].any?
-            %p.user_error
-              = @user.errors.messages[:phone_number][0]
 
         = f.submit "次へ進む", class: "information__submit"

--- a/db/migrate/20191113023613_remove_null_from_user.rb
+++ b/db/migrate/20191113023613_remove_null_from_user.rb
@@ -1,0 +1,7 @@
+class RemoveNullFromUser < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :users, :building_name, true 
+    change_column_null :users, :phone_number,  true 
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_11_11_053221) do
+ActiveRecord::Schema.define(version: 2019_11_13_023613) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -94,8 +93,8 @@ ActiveRecord::Schema.define(version: 2019_11_11_053221) do
     t.integer "prefectures", null: false
     t.string "city", null: false
     t.string "house_number", null: false
-    t.string "building_name", null: false
-    t.string "phone_number", null: false
+    t.string "building_name"
+    t.string "phone_number"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# What
ビル名と電話番号のバリデーションとnull制約を解除しました。
電話番号はsms確認ページのみ中身が空だとバリデーションがかかる状態にし、住所登録ページで電話番号を入力しなかった場合は登録しないようになっています。
ユーザー登録時のredirect_toの削除を行いました。

# Why
任意のデータにもバリデーションがかかっていたため。
登録時にリダイレクトが２回行われていたため。