### PR TITLE
Registration controllerの修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -44,7 +44,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     # カード情報のページをスキップしているためここでaddressのバリデーションチェックをします。本来はnew_cardで行います。
     validates_address
-    # binding.pry
     @user = User.new(
       nickname:              session[:nickname], # sessionに保存された値をインスタンスに渡す
       email:                 session[:email],
@@ -154,7 +153,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def validates_sms
     # smsで入力された値をsessionに保存
-    # binding.pry
     session[:phone_number] = user_params[:phone_number]
     @user = User.new(
       phone_number:          session[:phone_number],
@@ -184,7 +182,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session[:city]          = user_params[:city]
     session[:house_number]  = user_params[:house_number]
     session[:building_name] = user_params[:building_name]
-    # session[:phone_number]  = user_params[:phone_number]
     session[:phone_number_deliver]  = user_params[:phone_number_deliver]
 
     @user = User.new(

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -44,6 +44,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     # カード情報のページをスキップしているためここでaddressのバリデーションチェックをします。本来はnew_cardで行います。
     validates_address
+    # binding.pry
     @user = User.new(
       nickname:              session[:nickname], # sessionに保存された値をインスタンスに渡す
       email:                 session[:email],
@@ -63,7 +64,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       city:                  session[:city],
       house_number:          session[:house_number],
       building_name:         session[:building_name],
-      phone_number:          session[:phone_number]
+      phone_number:          session[:phone_number],
+      phone_number_deliver:  session[:phone_number_deliver]
     )
     if session[:user_attributes].present?
       @user.uid           = session[:user_attributes]["uid"]
@@ -104,7 +106,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       :city,
       :house_number,
       :building_name,
-      :phone_number
+      :phone_number,
+      :phone_number_deliver
   )
   end
 
@@ -151,9 +154,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def validates_sms
     # smsで入力された値をsessionに保存
+    # binding.pry
     session[:phone_number] = user_params[:phone_number]
     @user = User.new(
-      phone_number:          user_params[:phone_number],
+      phone_number:          session[:phone_number],
       nickname:              session[:nickname],
       email:                 session[:email],
       password:              session[:password],
@@ -180,7 +184,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session[:city]          = user_params[:city]
     session[:house_number]  = user_params[:house_number]
     session[:building_name] = user_params[:building_name]
-    session[:phone_number]  = user_params[:phone_number]
+    # session[:phone_number]  = user_params[:phone_number]
+    session[:phone_number_deliver]  = user_params[:phone_number_deliver]
 
     @user = User.new(
       nickname:              session[:nickname],
@@ -199,7 +204,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       city:                  user_params[:city],
       house_number:          user_params[:house_number],
       building_name:         user_params[:building_name],
-      phone_number:          user_params[:phone_number],
+      phone_number:          session[:phone_number],
+      phone_number_deliver:  user_params[:phone_number_deliver]
     )
     render :new_address unless @user.valid?
   end


### PR DESCRIPTION
# what
validates_addressメソッドで、電話番号が空に上書きされるようになっていたので、上書きされる原因となる式を削除しました。
電話番号が正常に登録できるようになりました。
https://gyazo.com/3f4f61fc2435e2c62a7642779f6cb7de
（最後の２行で正常登録を確認）

# why
電話番号を登録する必要がある。